### PR TITLE
Fix path to good scoring models

### DIFF
--- a/imp_tutorial_pol3/rnapoliii/analysis/.template.analysis.ipynb
+++ b/imp_tutorial_pol3/rnapoliii/analysis/.template.analysis.ipynb
@@ -432,7 +432,7 @@
    "outputs": [],
    "source": [
     "!imp_sampcon exhaust \\\n",
-    "       -n rnapoliii -p good_scoring_models/ \\\n",
+    "       -n rnapoliii -p modeling/good_scoring_models/ \\\n",
     "       -d density_ranges.txt -m cpu_omp -c 8 \\\n",
     "       -a -g 0.1 -gp"
    ]

--- a/imp_tutorial_pol3/rnapoliii/analysis/analysis.ipynb
+++ b/imp_tutorial_pol3/rnapoliii/analysis/analysis.ipynb
@@ -444,7 +444,7 @@
       "outputs": [],
       "source": [
         "!imp_sampcon exhaust \\\n",
-        "       -n rnapoliii -p good_scoring_models/ \\\n",
+        "       -n rnapoliii -p modeling/good_scoring_models/ \\\n",
         "       -d density_ranges.txt -m cpu_omp -c 8 \\\n",
         "       -a -g 0.1 -gp"
       ]


### PR DESCRIPTION
IMP.sampcon now puts good scoring models under
the modeling directory.